### PR TITLE
Issue #65 - Model Implementation: Add a v1 of the implementation

### DIFF
--- a/src/api/attestant/content-types/attestant/schema.json
+++ b/src/api/attestant/content-types/attestant/schema.json
@@ -9,43 +9,25 @@
   "options": {
     "draftAndPublish": true
   },
-  "pluginOptions": {
-    "i18n": {
-      "localized": true
-    }
-  },
+  "pluginOptions": {},
   "attributes": {
     "firstName": {
-      "type": "string",
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      }
+      "type": "string"
     },
     "lastName": {
-      "type": "string",
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      }
+      "type": "string"
+    },
+    "phone": {
+      "type": "string"
+    },
+    "email": {
+      "type": "email"
     },
     "role": {
-      "type": "string",
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      }
+      "type": "string"
     },
     "profilePicture": {
       "type": "media",
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
       "multiple": false,
       "allowedTypes": [
         "images",

--- a/src/api/company/content-types/company/schema.json
+++ b/src/api/company/content-types/company/schema.json
@@ -23,6 +23,10 @@
     "description": {
       "type": "text"
     },
+    "isPartner": {
+      "type": "boolean",
+      "default": false
+    },
     "icon": {
       "type": "media",
       "multiple": false,

--- a/src/api/company/content-types/company/schema.json
+++ b/src/api/company/content-types/company/schema.json
@@ -9,38 +9,22 @@
   "options": {
     "draftAndPublish": true
   },
-  "pluginOptions": {
-    "i18n": {
-      "localized": true
-    }
-  },
+  "pluginOptions": {},
   "attributes": {
     "slug": {
       "type": "uid"
     },
     "name": {
-      "type": "string",
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      }
+      "type": "string"
+    },
+    "website": {
+      "type": "string"
     },
     "description": {
-      "type": "text",
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      }
+      "type": "text"
     },
     "icon": {
       "type": "media",
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
       "multiple": false,
       "allowedTypes": [
         "images",
@@ -53,6 +37,12 @@
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::attestant.attestant",
+      "mappedBy": "company"
+    },
+    "quotations": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::quotation.quotation",
       "mappedBy": "company"
     }
   }

--- a/src/api/faq/content-types/faq/schema.json
+++ b/src/api/faq/content-types/faq/schema.json
@@ -1,0 +1,29 @@
+{
+  "kind": "singleType",
+  "collectionName": "faqs",
+  "info": {
+    "singularName": "faq",
+    "pluralName": "faqs",
+    "displayName": "FAQ"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "items": {
+      "type": "component",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "element.faq-item",
+      "repeatable": true
+    }
+  }
+}

--- a/src/api/faq/controllers/faq.ts
+++ b/src/api/faq/controllers/faq.ts
@@ -1,0 +1,7 @@
+/**
+ * faq controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::faq.faq');

--- a/src/api/faq/routes/faq.ts
+++ b/src/api/faq/routes/faq.ts
@@ -1,0 +1,7 @@
+/**
+ * faq router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::faq.faq');

--- a/src/api/faq/services/faq.ts
+++ b/src/api/faq/services/faq.ts
@@ -1,0 +1,7 @@
+/**
+ * faq service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::faq.faq');

--- a/src/api/game/content-types/game/schema.json
+++ b/src/api/game/content-types/game/schema.json
@@ -37,14 +37,6 @@
       "component": "element.text",
       "repeatable": false
     },
-    "isNew": {
-      "type": "boolean",
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      }
-    },
     "background": {
       "type": "media",
       "pluginOptions": {
@@ -98,6 +90,25 @@
         "videos",
         "audios"
       ]
+    },
+    "releaseDate": {
+      "type": "date",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "SEO": {
+      "type": "component",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "shared.seo",
+      "repeatable": false,
+      "required": false
     }
   }
 }

--- a/src/api/game/controllers/game.ts
+++ b/src/api/game/controllers/game.ts
@@ -35,6 +35,11 @@ export default factories.createCoreController('api::game.game', ({ strapi }) => 
                 background: true,
                 description: true,
                 pngIllustration: true,
+                SEO: {
+                    populate: {
+                        shareImage: true
+                    }
+                }
             }
         })
 

--- a/src/api/legal-document/content-types/legal-document/schema.json
+++ b/src/api/legal-document/content-types/legal-document/schema.json
@@ -1,0 +1,43 @@
+{
+  "kind": "collectionType",
+  "collectionName": "legal_documents",
+  "info": {
+    "singularName": "legal-document",
+    "pluralName": "legal-documents",
+    "displayName": "LegalDocument"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "slug": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "markdown": {
+      "type": "richtext",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    }
+  }
+}

--- a/src/api/legal-document/controllers/legal-document.ts
+++ b/src/api/legal-document/controllers/legal-document.ts
@@ -1,0 +1,24 @@
+/**
+ * legal-document controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::legal-document.legal-document', ({ strapi }) => ({
+    async findFirst(ctx) {
+        const { slug } = ctx.params;
+
+        const locale: string = ctx.request.query.locale as string;
+
+        const entity = await strapi.documents('api::legal-document.legal-document').findFirst({
+            locale,
+            filters: {
+                slug: {
+                    $eq: slug
+                }
+            }
+        })
+
+        return { data: entity };
+    },
+}));

--- a/src/api/legal-document/routes/custom-routes.ts
+++ b/src/api/legal-document/routes/custom-routes.ts
@@ -1,0 +1,11 @@
+
+export default {
+  routes: [
+    {
+      method: 'GET',
+      path: '/legal-documents/:slug',
+      handler: 'legal-document.findFirst',
+      config: { auth: false }
+    },
+  ],
+};

--- a/src/api/legal-document/routes/legal-document.ts
+++ b/src/api/legal-document/routes/legal-document.ts
@@ -1,0 +1,7 @@
+/**
+ * legal-document router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::legal-document.legal-document');

--- a/src/api/legal-document/services/legal-document.ts
+++ b/src/api/legal-document/services/legal-document.ts
@@ -1,0 +1,7 @@
+/**
+ * legal-document service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::legal-document.legal-document');

--- a/src/api/news-letter-subscription/content-types/news-letter-subscription/schema.json
+++ b/src/api/news-letter-subscription/content-types/news-letter-subscription/schema.json
@@ -13,13 +13,16 @@
   "attributes": {
     "email": {
       "type": "email",
+      "required": true,
       "unique": true
     },
-    "newsLetter": {
-      "type": "json"
+    "news": {
+      "type": "boolean",
+      "default": true
     },
-    "company": {
-      "type": "json"
+    "offers": {
+      "type": "boolean",
+      "default": true
     }
   }
 }

--- a/src/api/quotation-game/content-types/quotation-game/schema.json
+++ b/src/api/quotation-game/content-types/quotation-game/schema.json
@@ -1,0 +1,90 @@
+{
+  "kind": "collectionType",
+  "collectionName": "quotation_games",
+  "info": {
+    "singularName": "quotation-game",
+    "pluralName": "quotation-games",
+    "displayName": "QuotationGame"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "type": {
+      "type": "string",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "string",
+      "required": true
+    },
+    "detailedDescription": {
+      "type": "text",
+      "required": true
+    },
+    "photos": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
+    },
+    "rulesDocument": {
+      "type": "media",
+      "multiple": false,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
+    },
+    "devStage": {
+      "type": "string",
+      "required": true
+    },
+    "playersCount": {
+      "type": "string",
+      "required": true
+    },
+    "gameDuration": {
+      "type": "string",
+      "required": true
+    },
+    "recommendedAge": {
+      "type": "string",
+      "required": true
+    },
+    "complexity": {
+      "type": "string",
+      "required": true
+    },
+    "theme": {
+      "type": "string"
+    },
+    "uniqueFeatures": {
+      "type": "text"
+    },
+    "mainMechanic": {
+      "type": "string",
+      "required": true
+    },
+    "demoVideo": {
+      "type": "string"
+    },
+    "quotation": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::quotation.quotation",
+      "mappedBy": "quotationGame"
+    }
+  }
+}

--- a/src/api/quotation-game/controllers/quotation-game.ts
+++ b/src/api/quotation-game/controllers/quotation-game.ts
@@ -1,0 +1,7 @@
+/**
+ * quotation-game controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::quotation-game.quotation-game');

--- a/src/api/quotation-game/routes/quotation-game.ts
+++ b/src/api/quotation-game/routes/quotation-game.ts
@@ -1,0 +1,7 @@
+/**
+ * quotation-game router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::quotation-game.quotation-game');

--- a/src/api/quotation-game/services/quotation-game.ts
+++ b/src/api/quotation-game/services/quotation-game.ts
@@ -1,0 +1,7 @@
+/**
+ * quotation-game service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::quotation-game.quotation-game');

--- a/src/api/quotation/content-types/quotation/schema.json
+++ b/src/api/quotation/content-types/quotation/schema.json
@@ -1,0 +1,42 @@
+{
+  "kind": "collectionType",
+  "collectionName": "quotations",
+  "info": {
+    "singularName": "quotation",
+    "pluralName": "quotations",
+    "displayName": "Quotation"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "company": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::company.company",
+      "inversedBy": "quotations"
+    },
+    "quotationGame": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::quotation-game.quotation-game",
+      "inversedBy": "quotation"
+    },
+    "additionalInfo": {
+      "type": "text"
+    },
+    "budget": {
+      "type": "string",
+      "required": true
+    },
+    "deadline": {
+      "type": "string",
+      "required": true
+    },
+    "services": {
+      "type": "json",
+      "required": true
+    }
+  }
+}

--- a/src/api/quotation/controllers/quotation.ts
+++ b/src/api/quotation/controllers/quotation.ts
@@ -1,0 +1,7 @@
+/**
+ * quotation controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::quotation.quotation');

--- a/src/api/quotation/routes/quotation.ts
+++ b/src/api/quotation/routes/quotation.ts
@@ -1,0 +1,7 @@
+/**
+ * quotation router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::quotation.quotation');

--- a/src/api/quotation/services/quotation.ts
+++ b/src/api/quotation/services/quotation.ts
@@ -1,0 +1,7 @@
+/**
+ * quotation service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::quotation.quotation');

--- a/src/components/element/faq-item.json
+++ b/src/components/element/faq-item.json
@@ -1,0 +1,18 @@
+{
+  "collectionName": "components_element_faq_items",
+  "info": {
+    "displayName": "FaqItem"
+  },
+  "options": {},
+  "attributes": {
+    "question": {
+      "type": "string",
+      "required": true
+    },
+    "answers": {
+      "type": "richtext",
+      "required": true
+    }
+  },
+  "config": {}
+}

--- a/src/components/layout/blog-section.json
+++ b/src/components/layout/blog-section.json
@@ -18,6 +18,10 @@
       "default": 5,
       "min": 0
     },
+    "link": {
+      "type": "string",
+      "default": "/"
+    },
     "enableAnimation": {
       "type": "boolean",
       "required": true,

--- a/src/components/layout/footer.json
+++ b/src/components/layout/footer.json
@@ -24,6 +24,10 @@
       "component": "element.menu",
       "repeatable": true
     },
+    "newsletter": {
+      "type": "boolean",
+      "default": true
+    },
     "legal": {
       "type": "component",
       "component": "link.text-link",


### PR DESCRIPTION
### Description

This pull-request implement the backend side of the model implementation.

### Related Issue(s)

[#65](https://github.com/EnzoGrn/OMGG-Website/issues/65)

### Changes Made

- Company:
  - Remove localization.
  - Add a `isPartner` boolean, used for the website logos section.
  - Add a company `website` field and a link to the `quotation` content type.
- Attestant:
  - Remove localization.
  - Add contact fields (phone & email).
- QuotationGame:
  - All needed value for create a game quotation.
- Quotation:
  - The final value of a quotation, it contains services informations, budget, game informations, company

### Testing

Manual testing, with an development environment that includes **Insomnia** and website localhost version.

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.